### PR TITLE
Add CI workflow and switch to org-level reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+jobs:
+  Lint:
+    name: Lint
+    uses: constellos/.github/.github/workflows/reusable-lint.yml@main
+
+  Typecheck:
+    name: Typecheck
+    uses: constellos/.github/.github/workflows/reusable-typecheck.yml@main
+
+  Unit-Tests-Pass:
+    name: Unit Tests Pass
+    uses: constellos/.github/.github/workflows/reusable-unit-tests.yml@main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,40 +11,12 @@ on:
     types: [submitted]
 
 jobs:
-  claude:
+  Claude-Code:
+    name: Claude Code
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+    uses: constellos/.github/.github/workflows/reusable-claude-code.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add CI workflow with shared reusable workflows from constellos/.github
- Switch Claude Code workflow to use shared reusable workflow

## Test plan
- [ ] Verify CI jobs run correctly using reusable workflows
- [ ] Verify status checks appear with proper names

🤖 Generated with [Claude Code](https://claude.com/claude-code)