### PR TITLE
Add CI workflow with composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/lint@main
+
+  Typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/typecheck@main
+
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/unit-tests@main


### PR DESCRIPTION
## Summary
- Adds CI workflow using org-level composite actions
- Jobs skip gracefully when no package.json (this is a workflow-only repo)

## Jobs
- `Lint` - uses `constellos/.github/actions/lint@main`
- `Typecheck` - uses `constellos/.github/actions/typecheck@main`
- `Unit-Tests` - uses `constellos/.github/actions/unit-tests@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)