### PR TITLE
Test: Verify No CI on PRs

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,5 @@
+# Test PR
+
+This PR tests that:
+1. No CI workflow runs on PRs (expected - we removed it for marketplace)
+2. Only test-actions.yml runs on push to main


### PR DESCRIPTION
This PR demonstrates that no CI checks run on PRs in this repo (as expected after marketplace restructuring).

The workflow was moved to org-level reusable workflows.