### PR TITLE
fix: Use @main instead of @beta for claude-code-base-action

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Run review
       id: review
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*)"

--- a/.github/actions/context-reviewer/action.yml
+++ b/.github/actions/context-reviewer/action.yml
@@ -81,7 +81,7 @@ runs:
     - name: Run review
       if: steps.find.outputs.count != '0'
       id: review
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Grep,Bash(cat:*)"

--- a/.github/actions/hooks-reviewer/action.yml
+++ b/.github/actions/hooks-reviewer/action.yml
@@ -247,7 +247,7 @@ runs:
     - name: Run review
       if: steps.hook-config.outputs.skip_review != 'true'
       id: review
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Grep,Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(jq:*),Bash(file:*)"

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -118,7 +118,7 @@ runs:
     - name: Run review
       id: review
       if: steps.validate.outputs.skip != 'true'
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*)"

--- a/.github/actions/ux-reviewer/action.yml
+++ b/.github/actions/ux-reviewer/action.yml
@@ -104,7 +104,7 @@ runs:
     - name: Run review
       if: steps.context.outputs.relevant_count != '0'
       id: review
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*),Bash(ls:*)"

--- a/.github/actions/visual-reviewer/action.yml
+++ b/.github/actions/visual-reviewer/action.yml
@@ -143,7 +143,7 @@ runs:
     - name: Run review
       if: steps.check.outputs.count != '0'
       id: review
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_tools: "View,GlobTool,Bash(ls:*)"


### PR DESCRIPTION
## Summary

The `@beta` ref doesn't exist in `anthropics/claude-code-base-action`. This was causing all reviewer actions to fail with "Set up job" errors.

## Changes

Updated all 6 reviewer actions from:
```yaml
uses: anthropics/claude-code-base-action@beta
```
to:
```yaml
uses: anthropics/claude-code-base-action@main
```

## Affected Files

- requirements-reviewer/action.yml
- code-quality-reviewer/action.yml
- context-reviewer/action.yml
- visual-reviewer/action.yml
- ux-reviewer/action.yml
- hooks-reviewer/action.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)