### PR TITLE
fix: Handle permission errors in reviewer actions gracefully

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -42,7 +42,21 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         mkdir -p .claude/review-context
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt
+        # Gracefully handle permission errors
+        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
+
+    - name: Validate context
+      id: validate
+      shell: bash
+      run: |
+        SKIP="false"
+        SKIP_REASON=""
+        if [ ! -s ".claude/review-context/changed.txt" ]; then
+          SKIP="true"
+          SKIP_REASON="No changed files found or unable to access PR data"
+        fi
+        echo "skip=$SKIP" >> $GITHUB_OUTPUT
+        echo "skip_reason=$SKIP_REASON" >> $GITHUB_OUTPUT
 
     - name: Load agent prompt
       id: agent
@@ -63,6 +77,7 @@ runs:
 
     - name: Run review
       id: review
+      if: steps.validate.outputs.skip != 'true'
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
@@ -74,6 +89,26 @@ runs:
       id: extract
       shell: bash
       run: |
+        # Handle skipped case first
+        if [ "${{ steps.validate.outputs.skip }}" = "true" ]; then
+          REASON="${{ steps.validate.outputs.skip_reason }}"
+          echo "passed=true" >> $GITHUB_OUTPUT
+          echo "checks_passed=0" >> $GITHUB_OUTPUT
+          echo "checks_failed=0" >> $GITHUB_OUTPUT
+          echo "checks_skipped=4" >> $GITHUB_OUTPUT
+          RESULT=$(jq -n --arg reason "$REASON" '{
+            checks: [
+              {name: "DRY Compliance", status: "skipped", result: $reason, reasoning: $reason, files: []},
+              {name: "YAGNI Compliance", status: "skipped", result: $reason, reasoning: $reason, files: []},
+              {name: "Modularity", status: "skipped", result: $reason, reasoning: $reason, files: []},
+              {name: "Maintainability", status: "skipped", result: $reason, reasoning: $reason, files: []}
+            ],
+            message: $reason
+          }')
+          echo "result=$(echo "$RESULT" | jq -c '.')" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Initialize defaults
         CHECKS_PASSED=0
         CHECKS_FAILED=0

--- a/.github/actions/context-reviewer/action.yml
+++ b/.github/actions/context-reviewer/action.yml
@@ -44,7 +44,8 @@ runs:
       run: |
         mkdir -p .claude/review-context
 
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt
+        # Gracefully handle permission errors
+        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
 
         > .claude/review-context/claude_files.txt
         while IFS= read -r file; do

--- a/.github/actions/hooks-reviewer/action.yml
+++ b/.github/actions/hooks-reviewer/action.yml
@@ -58,7 +58,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt
+        # Gracefully handle permission errors
+        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
 
     - name: Prepare hook configuration
       id: hook-config

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -55,8 +55,8 @@ runs:
         [[ $BRANCH =~ ^([0-9]+)- ]] && ISSUE="${BASH_REMATCH[1]}"
         echo "issue=$ISSUE" >> $GITHUB_OUTPUT
 
-        # Get changed files
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt
+        # Get changed files (gracefully handle permission errors)
+        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
 
         # Get issue context if available
         if [ -n "$ISSUE" ]; then

--- a/.github/actions/ux-reviewer/action.yml
+++ b/.github/actions/ux-reviewer/action.yml
@@ -51,8 +51,8 @@ runs:
       run: |
         mkdir -p .claude/review-context
 
-        # Get changed files
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt
+        # Get changed files (gracefully handle permission errors)
+        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
 
         # Check if changes affect UI/UX related files
         RELEVANT=$(grep -E '\.(tsx?|jsx?|css|scss|html|vue|svelte)$' .claude/review-context/changed.txt | wc -l || echo "0")


### PR DESCRIPTION
## Summary

- Add error handling to `gh pr view` command in all 5 reviewer actions
- When the command fails (e.g., due to missing `pull_requests:read` permission), actions now skip gracefully instead of crashing
- Added validation step to code-quality-reviewer to match the pattern used by requirements-reviewer

## Test plan

- [ ] Deploy to a repository where the GitHub App lacks `pull_requests:read` permission
- [ ] Verify reviewer actions skip gracefully with `passed=true` and appropriate skip reasons
- [ ] Verify normal operation still works when permissions are correct

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)