### PR TITLE
feat: Improve comment format and add GitHub check run

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -81,8 +81,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*)"
-        max_turns: 15
         prompt: ${{ steps.agent.outputs.prompt }}
 
     - name: Extract result

--- a/.github/actions/context-reviewer/action.yml
+++ b/.github/actions/context-reviewer/action.yml
@@ -85,8 +85,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Grep,Bash(cat:*)"
-        max_turns: 15
         prompt: ${{ steps.agent.outputs.prompt }}
 
     - name: Extract result

--- a/.github/actions/create-check-run/action.yml
+++ b/.github/actions/create-check-run/action.yml
@@ -1,0 +1,51 @@
+name: Create Check Run
+description: Create a GitHub Check Run for Constellos reviews
+
+branding:
+  icon: 'check-circle'
+  color: 'purple'
+
+inputs:
+  sha:
+    description: 'Commit SHA for the check run'
+    required: true
+  conclusion:
+    description: 'Check conclusion (success, failure, neutral, cancelled, skipped, timed_out, action_required)'
+    required: true
+  summary:
+    description: 'Markdown summary of the check results'
+    required: true
+  title:
+    description: 'Title for the check run output'
+    required: false
+    default: 'AI Review Results'
+  github_token:
+    description: 'GitHub token with checks:write permission (must be App token)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Create check run
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      run: |
+        SHA="${{ inputs.sha }}"
+        CONCLUSION="${{ inputs.conclusion }}"
+        TITLE="${{ inputs.title }}"
+
+        # Read summary from input (handle multiline)
+        SUMMARY='${{ inputs.summary }}'
+
+        # Create the check run using GitHub API
+        gh api \
+          --method POST \
+          "/repos/${{ github.repository }}/check-runs" \
+          -f name="Constellos Agent Reviews" \
+          -f head_sha="$SHA" \
+          -f status="completed" \
+          -f conclusion="$CONCLUSION" \
+          -f "output[title]=$TITLE" \
+          -f "output[summary]=$SUMMARY" \
+          || echo "::warning::Failed to create check run. Ensure the GitHub App has 'checks: write' permission."

--- a/.github/actions/hooks-reviewer/action.yml
+++ b/.github/actions/hooks-reviewer/action.yml
@@ -251,8 +251,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Grep,Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(jq:*),Bash(file:*)"
-        max_turns: 20
         prompt: ${{ steps.agent.outputs.prompt }}
         settings: ${{ steps.hook-config.outputs.settings_json }}
 

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -124,8 +124,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*)"
-        max_turns: 15
         prompt: ${{ steps.agent.outputs.prompt }}
 
     - name: Extract result

--- a/.github/actions/review-comment/action.yml
+++ b/.github/actions/review-comment/action.yml
@@ -65,17 +65,8 @@ runs:
           STATUS_EMOJI="⚠️"
         fi
 
-        # Build summary line with bullet separator and lowercase
-        SUMMARY_PARTS=""
-        [ "$CHECKS_PASSED" -gt 0 ] && SUMMARY_PARTS="✅ $CHECKS_PASSED passed"
-        if [ "$CHECKS_FAILED" -gt 0 ]; then
-          [ -n "$SUMMARY_PARTS" ] && SUMMARY_PARTS="$SUMMARY_PARTS • "
-          SUMMARY_PARTS="${SUMMARY_PARTS}❌ $CHECKS_FAILED failed"
-        fi
-        if [ "$CHECKS_SKIPPED" -gt 0 ]; then
-          [ -n "$SUMMARY_PARTS" ] && SUMMARY_PARTS="$SUMMARY_PARTS • "
-          SUMMARY_PARTS="${SUMMARY_PARTS}⚠️ $CHECKS_SKIPPED skipped"
-        fi
+        # Build summary line - always show all three counts
+        SUMMARY_PARTS="✅ $CHECKS_PASSED passed • ❌ $CHECKS_FAILED failed • ⚠️ $CHECKS_SKIPPED skipped"
 
         # Build prompt link
         PROMPT_LINK=""
@@ -84,8 +75,8 @@ runs:
         fi
 
         # Build checks table header
-        CHECKS_TABLE="| Check | Status | Result | Reasoning |"
-        CHECKS_TABLE="${CHECKS_TABLE}"$'\n'"|-------|--------|--------|-----------|"
+        CHECKS_TABLE="| Check | Status | Reasoning |"
+        CHECKS_TABLE="${CHECKS_TABLE}"$'\n'"|-------|--------|-----------|"
 
         # Parse checks from JSON
         CHECKS_COUNT=$(echo "$RESULT" | jq '.checks | length' 2>/dev/null || echo "0")
@@ -93,7 +84,6 @@ runs:
         for i in $(seq 0 $((CHECKS_COUNT - 1))); do
           CHECK_NAME=$(echo "$RESULT" | jq -r ".checks[$i].name // \"Check $i\"")
           CHECK_STATUS=$(echo "$RESULT" | jq -r ".checks[$i].status // \"skipped\"")
-          CHECK_RESULT=$(echo "$RESULT" | jq -r ".checks[$i].result // \"N/A\"")
           CHECK_REASONING=$(echo "$RESULT" | jq -r ".checks[$i].reasoning // \"N/A\"")
 
           # Status emoji for check
@@ -125,18 +115,14 @@ runs:
           fi
 
           # Escape pipe characters in content
-          CHECK_RESULT=$(echo "$CHECK_RESULT" | sed 's/|/\\|/g')
           CHECK_REASONING=$(echo "$CHECK_REASONING" | sed 's/|/\\|/g')
 
           # Add reasoning with files detail if present
           REASONING_CELL="$CHECK_REASONING"
           [ -n "$FILES_DETAIL" ] && REASONING_CELL="$CHECK_REASONING $FILES_DETAIL"
 
-          CHECKS_TABLE="${CHECKS_TABLE}"$'\n'"| $CHECK_NAME | $CHECK_EMOJI | $CHECK_RESULT | $REASONING_CELL |"
+          CHECKS_TABLE="${CHECKS_TABLE}"$'\n'"| $CHECK_NAME | $CHECK_EMOJI | $REASONING_CELL |"
         done
-
-        # Get optional message
-        MESSAGE=$(echo "$RESULT" | jq -r '.message // ""' 2>/dev/null)
 
         # Build the full agent section
         echo "<details>" > /tmp/agent_section.md
@@ -145,13 +131,6 @@ runs:
         echo "$PROMPT_LINK" >> /tmp/agent_section.md
         echo "" >> /tmp/agent_section.md
         echo "$CHECKS_TABLE" >> /tmp/agent_section.md
-
-        # Add message if present
-        if [ -n "$MESSAGE" ] && [ "$MESSAGE" != "" ] && [ "$MESSAGE" != "null" ]; then
-          echo "" >> /tmp/agent_section.md
-          echo "> $MESSAGE" >> /tmp/agent_section.md
-        fi
-
         echo "" >> /tmp/agent_section.md
         echo "</details>" >> /tmp/agent_section.md
 
@@ -188,10 +167,8 @@ runs:
           # Remove existing agent block if present
           NEW_BODY=$(echo "$OLD_BODY" | perl -0777 -pe "s/<!-- agent:$REVIEW -->.*?<!-- \\/agent:$REVIEW -->\n?//gs")
 
-          # Insert new agent block before the footer
-          NEW_BODY=$(echo "$NEW_BODY" | sed "/^---$/i\\
-        $AGENT_BLOCK
-        ")
+          # Append new agent block
+          NEW_BODY="${NEW_BODY}"$'\n'"${AGENT_BLOCK}"
 
           gh api --method PATCH "/repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -f body="$NEW_BODY"
         else
@@ -200,12 +177,7 @@ runs:
             echo "$MARKER"
             echo "Updates on your PR checks from AI reviewers."
             echo ""
-            echo "---"
-            echo ""
             echo "$AGENT_BLOCK"
-            echo ""
-            echo "---"
-            echo "*Constellos*"
           } > /tmp/comment.md
 
           gh pr comment "$PR" --body-file /tmp/comment.md

--- a/.github/actions/ux-reviewer/action.yml
+++ b/.github/actions/ux-reviewer/action.yml
@@ -107,8 +107,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Grep,Bash(git diff:*),Bash(cat:*),Bash(ls:*)"
-        max_turns: 15
         prompt: ${{ steps.agent.outputs.prompt }}
 
     - name: Extract result

--- a/.github/actions/visual-reviewer/action.yml
+++ b/.github/actions/visual-reviewer/action.yml
@@ -146,9 +146,6 @@ runs:
       uses: anthropics/claude-code-base-action@main
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        allowed_tools: "View,GlobTool,Bash(ls:*)"
-        max_turns: 20
-        model: ${{ inputs.model }}
         prompt: ${{ steps.agent.outputs.prompt }}
 
     - name: Extract result


### PR DESCRIPTION
## Summary
- Remove invalid `allowed_tools` and `max_turns` inputs from all 6 reviewer actions
- Clean up comment format: remove dividers, footer, Result column, blockquote message
- Always show all three counts (passed, failed, skipped) in summary line
- Add new `create-check-run` action for GitHub Checks API integration

## Changes
- **Reviewer actions**: Removed unsupported inputs that were causing warnings
- **review-comment**: Simplified format, removed visual clutter
- **create-check-run**: New action that creates branded check runs in GitHub Checks tab

## Expected Result
- No more "unexpected input" warnings in action logs
- Cleaner PR comment format
- "Constellos Agent Reviews" appears in GitHub Checks tab (like Vercel)

## Requirements
- GitHub App must have `checks: write` permission added

## Test plan
- [ ] Create test PR after merge
- [ ] Verify no warnings in action logs
- [ ] Verify comment format is clean
- [ ] Verify check run appears in Checks tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)