### PR TITLE
fix: Escape JSON properly in review-comment action

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "enabledPlugins": {
-    "github-context@constellos": true,
+    "github-orchestration@constellos": true,
     "project-context@constellos": true
   }
 }

--- a/.github/actions/review-comment/action.yml
+++ b/.github/actions/review-comment/action.yml
@@ -46,10 +46,11 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        RESULT_JSON: ${{ inputs.result_json }}
       run: |
         REVIEW="${{ inputs.review_name }}"
         PASSED="${{ inputs.passed }}"
-        RESULT='${{ inputs.result_json }}'
+        RESULT="$RESULT_JSON"
         CHECKS_PASSED="${{ inputs.checks_passed }}"
         CHECKS_FAILED="${{ inputs.checks_failed }}"
         CHECKS_SKIPPED="${{ inputs.checks_skipped }}"


### PR DESCRIPTION
## Summary
- Fix bash syntax error when JSON contains special characters like parentheses
- Update settings to use github-orchestration plugin

## Problem
The `review-comment` action was failing with:
```
syntax error near unexpected token `('
```

This happened because the JSON result was passed via direct string interpolation:
```bash
RESULT='${{ inputs.result_json }}'
```

When the JSON contained text like `(checkout, setup-bun, install)`, bash interpreted the parentheses as command substitution syntax.

## Solution
Pass the JSON via environment variable instead:
```yaml
env:
  RESULT_JSON: ${{ inputs.result_json }}
run: |
  RESULT="$RESULT_JSON"
```

Environment variables are properly escaped and won't be parsed by bash.

## Test plan
- [ ] Re-run the failed PR #286 on claude-code-plugins after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)