### PR TITLE
fix: Guard against empty check count values in review-comment action

### DIFF
--- a/.github/actions/review-comment/action.yml
+++ b/.github/actions/review-comment/action.yml
@@ -17,13 +17,16 @@ inputs:
     required: true
   checks_passed:
     description: 'Number of checks that passed'
-    required: true
+    required: false
+    default: '0'
   checks_failed:
     description: 'Number of checks that failed'
-    required: true
+    required: false
+    default: '0'
   checks_skipped:
     description: 'Number of checks that were skipped'
-    required: true
+    required: false
+    default: '0'
   pr_number:
     description: 'Pull request number'
     required: true
@@ -55,6 +58,11 @@ runs:
         CHECKS_FAILED="${{ inputs.checks_failed }}"
         CHECKS_SKIPPED="${{ inputs.checks_skipped }}"
         PROMPT_FILE="${{ inputs.prompt_file }}"
+
+        # Guard against empty values (issue #4)
+        CHECKS_PASSED="${CHECKS_PASSED:-0}"
+        CHECKS_FAILED="${CHECKS_FAILED:-0}"
+        CHECKS_SKIPPED="${CHECKS_SKIPPED:-0}"
 
         # Determine status emoji based on check counts (not just passed boolean)
         if [ "$CHECKS_PASSED" -gt 0 ] && [ "$CHECKS_FAILED" -eq 0 ]; then
@@ -156,6 +164,10 @@ runs:
         PASSED="${{ inputs.passed }}"
         CHECKS_PASSED="${{ inputs.checks_passed }}"
         CHECKS_FAILED="${{ inputs.checks_failed }}"
+
+        # Guard against empty values (issue #4)
+        CHECKS_PASSED="${CHECKS_PASSED:-0}"
+        CHECKS_FAILED="${CHECKS_FAILED:-0}"
 
         # Read the generated section
         AGENT_SECTION=$(cat /tmp/agent_section.md)

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ pnpm-lock.yaml
 
 # TypeScript
 *.tsbuildinfo
+
+# nodes-md MCP config
+.nodes/


### PR DESCRIPTION
## Summary

- Add default values (`'0'`) to `checks_passed`, `checks_failed`, `checks_skipped` inputs
- Add bash guards (`${VAR:-0}`) to handle empty string values at runtime
- Prevents "integer expression expected" errors when reviewer step is skipped or fails

Fixes #45

## Root Cause

When the reviewer step fails or is skipped, the `review-comment` action still runs (due to `if: always()`), but receives empty strings instead of numeric values. Bash's `[ ]` test comparisons like `-gt` and `-eq` require valid integers, causing the error.

## Changes

**`.github/actions/review-comment/action.yml`:**
1. Changed inputs from `required: true` to `required: false` with `default: '0'`
2. Added bash guards after variable assignment in both shell scripts

## Test plan

- [ ] Create test PR and verify no "integer expression expected" error
- [ ] Verify STATUS_EMOJI defaults to "⚠️" when all counts are 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)