### PR TITLE
feat: Add native GitHub issue-branch linking and closingIssuesReferences fallback

### DIFF
--- a/.claude/hooks/link-branch-to-issue.sh
+++ b/.claude/hooks/link-branch-to-issue.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Link current branch to GitHub issue using native "Development" section
+#
+# Usage: link-branch-to-issue.sh <issue-number>
+#
+# This creates a proper GitHub link that shows in the issue's "Development"
+# sidebar, avoiding namespace collisions between issues and PRs.
+#
+# Note: createLinkedBranch only works for NEW branches. For existing branches,
+# we fall back to storing the mapping in .claude/logs/branch-issues.json
+
+set -euo pipefail
+
+ISSUE_NUMBER="${1:-}"
+if [ -z "$ISSUE_NUMBER" ]; then
+  echo "No issue number provided, skipping link"
+  exit 0
+fi
+
+# Get repo info from git remote
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+if [ -z "$REMOTE_URL" ]; then
+  echo "No git remote found"
+  exit 0
+fi
+
+# Extract owner/repo from remote URL
+# Handles: git@github.com:owner/repo.git, https://github.com/owner/repo.git
+REPO_FULL=$(echo "$REMOTE_URL" | sed -E 's#^(git@github\.com:|https://github\.com/)##' | sed 's/\.git$//')
+REPO_OWNER=$(echo "$REPO_FULL" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO_FULL" | cut -d'/' -f2)
+
+if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
+  echo "Could not parse repo from remote: $REMOTE_URL"
+  exit 0
+fi
+
+BRANCH=$(git branch --show-current)
+if [ -z "$BRANCH" ]; then
+  echo "Not on a branch"
+  exit 0
+fi
+
+echo "Linking branch '$BRANCH' to issue #$ISSUE_NUMBER in $REPO_OWNER/$REPO_NAME"
+
+# Get issue node ID (required for GraphQL mutation)
+ISSUE_ID=$(gh api graphql -f query="
+  query {
+    repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+      issue(number: $ISSUE_NUMBER) { id }
+    }
+  }" --jq '.data.repository.issue.id' 2>/dev/null || echo "")
+
+if [ -z "$ISSUE_ID" ] || [ "$ISSUE_ID" = "null" ]; then
+  echo "Could not find issue #$ISSUE_NUMBER"
+  exit 0
+fi
+
+# Check if branch already exists on remote
+BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | wc -l)
+
+if [ "$BRANCH_EXISTS" -gt 0 ]; then
+  # Branch exists - createLinkedBranch won't work
+  # Check if it's already linked
+  EXISTING_LINK=$(gh api graphql -f query="
+    query {
+      repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+        issue(number: $ISSUE_NUMBER) {
+          linkedBranches(first: 10) {
+            nodes { ref { name } }
+          }
+        }
+      }
+    }" --jq ".data.repository.issue.linkedBranches.nodes[].ref.name | select(. == \"$BRANCH\")" 2>/dev/null || echo "")
+
+  if [ -n "$EXISTING_LINK" ]; then
+    echo "Branch '$BRANCH' is already linked to issue #$ISSUE_NUMBER"
+  else
+    echo "Branch already exists on remote. GitHub's createLinkedBranch only works for new branches."
+    echo "The link will be established when a PR is created with 'Closes #$ISSUE_NUMBER' in the body."
+  fi
+else
+  # Branch doesn't exist on remote - try createLinkedBranch
+  OID=$(git rev-parse HEAD)
+
+  RESULT=$(gh api graphql -f query="
+    mutation {
+      createLinkedBranch(input: {
+        issueId: \"$ISSUE_ID\",
+        oid: \"$OID\",
+        name: \"$BRANCH\"
+      }) {
+        linkedBranch {
+          ref { name }
+        }
+      }
+    }" 2>&1 || echo "FAILED")
+
+  if echo "$RESULT" | grep -q "FAILED\|errors"; then
+    echo "Could not create linked branch via GitHub API."
+    echo "This may be because the branch needs to be pushed first."
+    echo "The link will be established when a PR is created."
+  else
+    echo "Successfully linked branch '$BRANCH' to issue #$ISSUE_NUMBER"
+  fi
+fi
+
+# Always update local tracking file as a fallback/cache
+LOGS_DIR="$(git rev-parse --show-toplevel)/.claude/logs"
+mkdir -p "$LOGS_DIR"
+TRACKING_FILE="$LOGS_DIR/branch-issues.json"
+
+if [ -f "$TRACKING_FILE" ]; then
+  # Update existing file
+  jq --arg branch "$BRANCH" \
+     --argjson issue "$ISSUE_NUMBER" \
+     --arg url "https://github.com/$REPO_OWNER/$REPO_NAME/issues/$ISSUE_NUMBER" \
+     --arg now "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+     '.[$branch] = {issueNumber: $issue, issueUrl: $url, createdAt: $now, linkedViaHook: true}' \
+     "$TRACKING_FILE" > "$TRACKING_FILE.tmp" && mv "$TRACKING_FILE.tmp" "$TRACKING_FILE"
+else
+  # Create new file
+  jq -n --arg branch "$BRANCH" \
+        --argjson issue "$ISSUE_NUMBER" \
+        --arg url "https://github.com/$REPO_OWNER/$REPO_NAME/issues/$ISSUE_NUMBER" \
+        --arg now "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+        '{($branch): {issueNumber: $issue, issueUrl: $url, createdAt: $now, linkedViaHook: true}}' \
+        > "$TRACKING_FILE"
+fi
+
+echo "Updated local tracking in $TRACKING_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
   "enabledPlugins": {
     "github-orchestration@constellos": true,
     "project-context@constellos": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/link-branch-to-issue.sh ${ISSUE_NUMBER:-}",
+            "statusMessage": "Linking branch to GitHub issue"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -57,10 +57,30 @@ runs:
         ISSUE=""
         [[ $BRANCH =~ ^([0-9]+)- ]] && ISSUE="${BASH_REMATCH[1]}"
 
-        # Fallback: Parse PR body for "Closes #X", "Fixes #X", "Resolves #X"
+        # Fallback 1: Parse PR body for "Closes #X", "Fixes #X", "Resolves #X"
         if [ -z "$ISSUE" ]; then
           PR_BODY=$(gh pr view ${{ inputs.pr_number }} --json body --jq '.body' 2>/dev/null || echo "")
           ISSUE=$(echo "$PR_BODY" | grep -oP '(Closes|Fixes|Resolves)\s+#\K[0-9]+' | head -1 || echo "")
+        fi
+
+        # Fallback 2: Query GitHub's closingIssuesReferences API
+        # This uses GitHub's native issue linking detection
+        if [ -z "$ISSUE" ]; then
+          ISSUE=$(gh api graphql -f query='
+            query($owner: String!, $name: String!, $pr: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 1) {
+                    nodes { number }
+                  }
+                }
+              }
+            }' -f owner='${{ github.repository_owner }}' \
+               -f name='${{ github.event.repository.name }}' \
+               -F pr=${{ inputs.pr_number }} \
+               --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[0].number' 2>/dev/null || echo "")
+          # Clean up null/empty responses
+          [ "$ISSUE" = "null" ] && ISSUE=""
         fi
 
         echo "issue=$ISSUE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Add hook script for native GitHub branch-issue linking using `createLinkedBranch` mutation
- Add `closingIssuesReferences` GraphQL fallback to requirements-reviewer
- Configure SessionStart hook in settings.json

## Changes

### New: `.claude/hooks/link-branch-to-issue.sh`
Hook script that:
- Uses GitHub's native `createLinkedBranch` mutation for new branches (creates proper "Development" section link)
- Falls back to local tracking when branch already exists on remote
- Updates `.claude/logs/branch-issues.json` as a cache

### Updated: `.github/actions/requirements-reviewer/action.yml`
Added third fallback for issue detection:
1. Branch name parsing (`123-feature` → #123)
2. PR body keywords (`Closes #X`, `Fixes #X`, `Resolves #X`)
3. **New:** GitHub's `closingIssuesReferences` GraphQL API

### Updated: `.claude/settings.json`
Added SessionStart hook configuration to run the link script when `ISSUE_NUMBER` is provided.

## Why This Matters
- Resolves namespace collision between issues and PRs (e.g., branch `51-something` could mean issue #51 or PR #51)
- Uses GitHub's native Development section for proper issue-branch linking
- Provides multiple fallback methods for requirements-reviewer to find linked issues

Closes #52

## Test plan
- [x] Verify hook script syntax with `bash -n`
- [x] Test hook script manually with existing branch (falls back correctly)
- [ ] Test with new branch creation (uses `createLinkedBranch`)
- [ ] Create test PR to verify `closingIssuesReferences` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)