### PR TITLE
fix: Use github.action_path for shared script reference

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -130,7 +130,7 @@ runs:
       shell: bash
       run: |
         # Use shared extraction logic
-        source "${{ github.workspace }}/.github/actions/shared/extract-result.sh"
+        source "${{ github.action_path }}/../shared/extract-result.sh"
 
         # Handle skipped case first
         if [ "${{ steps.validate.outputs.skip }}" = "true" ]; then

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -169,7 +169,7 @@ runs:
       shell: bash
       run: |
         # Use shared extraction logic
-        source "${{ github.workspace }}/.github/actions/shared/extract-result.sh"
+        source "${{ github.action_path }}/../shared/extract-result.sh"
 
         # Handle skipped case first
         if [ "${{ steps.validate.outputs.skip }}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Fix reviewer actions to use `github.action_path` instead of `github.workspace` for the shared script path
- This fixes "No such file or directory" error when actions are used in external repos

## Problem
The reviewer actions were sourcing `extract-result.sh` using `${{ github.workspace }}`, which points to the consuming repo's workspace. When constellos/constellos uses these actions, the script doesn't exist there.

## Solution
Changed to `${{ github.action_path }}/../shared/extract-result.sh` which correctly references the script relative to the action's own directory.

## Test plan
- [ ] Verify test PR #32 in constellos/constellos runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)