### PR TITLE
fix: Fail CI when review checks fail

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -152,3 +152,9 @@ runs:
         echo "checks_passed=$CHECKS_PASSED" >> $GITHUB_OUTPUT
         echo "checks_failed=$CHECKS_FAILED" >> $GITHUB_OUTPUT
         echo "checks_skipped=$CHECKS_SKIPPED" >> $GITHUB_OUTPUT
+
+        # Fail CI if any checks failed
+        if [ "$CHECKS_FAILED" -gt 0 ]; then
+          echo "::error::$CHECKS_FAILED check(s) failed"
+          exit 1
+        fi

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -193,3 +193,9 @@ runs:
         echo "checks_passed=$CHECKS_PASSED" >> $GITHUB_OUTPUT
         echo "checks_failed=$CHECKS_FAILED" >> $GITHUB_OUTPUT
         echo "checks_skipped=$CHECKS_SKIPPED" >> $GITHUB_OUTPUT
+
+        # Fail CI if any checks failed
+        if [ "$CHECKS_FAILED" -gt 0 ]; then
+          echo "::error::$CHECKS_FAILED check(s) failed"
+          exit 1
+        fi


### PR DESCRIPTION
## Summary

- Add CI failure when review checks fail in requirements and code-quality reviewers
- When `CHECKS_FAILED > 0`, actions now exit with error annotation and status 1
- Ensures PRs can't be merged when review checks fail (with branch protection)

Closes #57

## Test plan

- [ ] Create a test PR that triggers a failing review check
- [ ] Verify CI shows as failed with error message
- [ ] Verify error annotation is visible in GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)