### PR TITLE
feat: Add CI caller workflow + auto-sync review template

### DIFF
--- a/.github/actions/sync-workflow/action.yml
+++ b/.github/actions/sync-workflow/action.yml
@@ -1,0 +1,62 @@
+name: Sync Constellos Review Workflow
+description: Fetches the latest constellos-review.yml template and updates the local copy if outdated
+
+inputs:
+  workflow_path:
+    description: Path to the local workflow file to sync
+    required: false
+    default: .github/workflows/constellos-review.yml
+  template_url:
+    description: URL to fetch the latest template from
+    required: false
+    default: https://raw.githubusercontent.com/constellos/github-agents/main/.github/templates/constellos-review.yml
+
+runs:
+  using: composite
+  steps:
+    - name: Sync workflow file
+      shell: bash
+      env:
+        WORKFLOW_PATH: ${{ inputs.workflow_path }}
+        TEMPLATE_URL: ${{ inputs.template_url }}
+      run: |
+        echo "::group::Sync constellos-review.yml"
+
+        # Fetch latest template
+        LATEST=$(curl -fsSL "$TEMPLATE_URL" 2>&1) || {
+          echo "::warning::Failed to fetch latest template from $TEMPLATE_URL"
+          echo "::endgroup::"
+          exit 0
+        }
+
+        # Compare with local copy
+        if [ -f "$WORKFLOW_PATH" ]; then
+          LOCAL=$(cat "$WORKFLOW_PATH")
+          if [ "$LATEST" = "$LOCAL" ]; then
+            echo "Workflow is up to date."
+            echo "::endgroup::"
+            exit 0
+          fi
+        fi
+
+        echo "Workflow is outdated — updating."
+        mkdir -p "$(dirname "$WORKFLOW_PATH")"
+        echo "$LATEST" > "$WORKFLOW_PATH"
+
+        # Configure git and push
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add "$WORKFLOW_PATH"
+        git commit -m "chore: sync constellos-review.yml from template" || {
+          echo "::warning::Nothing to commit (file unchanged after write)."
+          echo "::endgroup::"
+          exit 0
+        }
+        git push || {
+          echo "::warning::Failed to push workflow sync commit. The PR branch may be from a fork."
+          echo "::endgroup::"
+          exit 0
+        }
+
+        echo "Workflow synced successfully."
+        echo "::endgroup::"

--- a/.github/templates/constellos-review.yml
+++ b/.github/templates/constellos-review.yml
@@ -15,6 +15,18 @@ permissions:
   pull-requests: read  # REQUIRED: agents need this to fetch changed files via gh pr view
 
 jobs:
+  # Auto-sync this workflow from the latest template
+  sync-workflow:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: constellos/github-agents/.github/actions/sync-workflow@main
+
   # Read config and determine which agents to run
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,0 +1,10 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  CI:
+    uses: constellos/.github/.github/workflows/ci-pipeline-reusable.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds thin CI caller workflow (`.github/workflows/ci-pipeline.yml`) that delegates to the reusable pipeline at `constellos/.github`
- Adds auto-sync composite action (`.github/actions/sync-workflow/action.yml`) that keeps consumer repos' `constellos-review.yml` up to date automatically
- Updates the review template to include a `sync-workflow` job so consumers get template fixes without manual intervention

Closes #74
Closes #73

## Test plan
- [ ] Verify `ci-pipeline.yml` triggers CI on PRs
- [ ] Verify `sync-workflow` action fetches and compares templates correctly
- [ ] Verify fork PRs skip the sync job gracefully
- [ ] Verify review jobs still run in parallel (no dependency on sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)