### PR TITLE
fix: Surface permission errors instead of silently skipping reviews

### DIFF
--- a/.github/actions/code-quality-reviewer/action.yml
+++ b/.github/actions/code-quality-reviewer/action.yml
@@ -42,8 +42,12 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         mkdir -p .claude/review-context
-        # Gracefully handle permission errors
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
+        # Get changed files — capture errors instead of suppressing them
+        if ! gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/tmp/gh-error.log; then
+          echo "::warning::Failed to fetch PR files. Check that the workflow has 'pull-requests: read' permission."
+          cat /tmp/gh-error.log >&2
+          touch .claude/review-context/changed.txt
+        fi
 
     - name: Validate context
       id: validate
@@ -53,7 +57,11 @@ runs:
         SKIP_REASON=""
         if [ ! -s ".claude/review-context/changed.txt" ]; then
           SKIP="true"
-          SKIP_REASON="No changed files found or unable to access PR data"
+          if [ -f /tmp/gh-error.log ] && grep -qi "403\|forbidden\|permission\|Resource not accessible" /tmp/gh-error.log; then
+            SKIP_REASON="Missing 'pull-requests: read' permission — add it to workflow permissions block"
+          else
+            SKIP_REASON="No changed files found or unable to access PR data"
+          fi
         fi
         echo "skip=$SKIP" >> $GITHUB_OUTPUT
         echo "skip_reason=$SKIP_REASON" >> $GITHUB_OUTPUT

--- a/.github/actions/context-reviewer/action.yml
+++ b/.github/actions/context-reviewer/action.yml
@@ -47,16 +47,28 @@ runs:
       run: |
         mkdir -p .claude/review-context
 
-        # Get changed files
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
+        # Get changed files — capture errors instead of suppressing them
+        if ! gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/tmp/gh-error.log; then
+          echo "::warning::Failed to fetch PR files. Check that the workflow has 'pull-requests: read' permission."
+          cat /tmp/gh-error.log >&2
+          touch .claude/review-context/changed.txt
+        fi
 
         # Get PR details
-        gh pr view ${{ inputs.pr_number }} --json title,body,author > .claude/review-context/pr.json 2>/dev/null || echo '{}' > .claude/review-context/pr.json
+        if ! gh pr view ${{ inputs.pr_number }} --json title,body,author > .claude/review-context/pr.json 2>/tmp/gh-pr-error.log; then
+          echo "::warning::Failed to fetch PR details. Check that the workflow has 'pull-requests: read' permission."
+          cat /tmp/gh-pr-error.log >&2
+          echo '{}' > .claude/review-context/pr.json
+        fi
 
         # Check if we have context
         if [ ! -s ".claude/review-context/changed.txt" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
-          echo "skip_reason=No changed files found" >> $GITHUB_OUTPUT
+          if [ -f /tmp/gh-error.log ] && grep -qi "403\|forbidden\|permission\|Resource not accessible" /tmp/gh-error.log; then
+            echo "skip_reason=Missing 'pull-requests: read' permission — add it to workflow permissions block" >> $GITHUB_OUTPUT
+          else
+            echo "skip_reason=No changed files found or unable to access PR data" >> $GITHUB_OUTPUT
+          fi
         else
           echo "skip=false" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/requirements-reviewer/action.yml
+++ b/.github/actions/requirements-reviewer/action.yml
@@ -91,8 +91,12 @@ runs:
 
         echo "issue=$ISSUE" >> $GITHUB_OUTPUT
 
-        # Get changed files (gracefully handle permission errors)
-        gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/dev/null || touch .claude/review-context/changed.txt
+        # Get changed files — capture errors instead of suppressing them
+        if ! gh pr view ${{ inputs.pr_number }} --json files --jq '.files[].path' > .claude/review-context/changed.txt 2>/tmp/gh-error.log; then
+          echo "::warning::Failed to fetch PR files. Check that the workflow has 'pull-requests: read' permission."
+          cat /tmp/gh-error.log >&2
+          touch .claude/review-context/changed.txt
+        fi
 
         # Get issue context if available
         if [ -n "$ISSUE" ]; then
@@ -116,7 +120,11 @@ runs:
         # Check if changed files exist and have content
         if [ ! -s ".claude/review-context/changed.txt" ]; then
           SKIP="true"
-          SKIP_REASON="No changed files found or unable to access PR data"
+          if [ -f /tmp/gh-error.log ] && grep -qi "403\|forbidden\|permission\|Resource not accessible" /tmp/gh-error.log; then
+            SKIP_REASON="Missing 'pull-requests: read' permission — add it to workflow permissions block"
+          else
+            SKIP_REASON="No changed files found or unable to access PR data"
+          fi
         fi
 
         # Check if issue context has actual content (not just {})


### PR DESCRIPTION
## Summary
- Replace silent `2>/dev/null || touch` error suppression in all 3 reviewer actions with error-capturing logic that logs `::warning::` annotations pointing to the likely fix (`pull-requests: read` permission)
- Update validation/skip logic to detect 403/permission errors and surface a specific skip reason instead of the generic "No changed files found"
- Also fix the context reviewer's `gh pr view --json title,body,author` call which had the same silent suppression

Closes #76

## Test plan
- [ ] Run existing workflow on a test PR in this repo to confirm actions still work with correct permissions
- [ ] Verify that when `pull-requests: read` is missing, the action logs a `::warning::` annotation with the fix instead of silently skipping
- [ ] After updating the constellos/constellos workflow, re-run PR #75's checks to confirm reviews execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)